### PR TITLE
Replace sketch-toolbox with sketchpacks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -134,7 +134,7 @@ cask 'github-desktop'
 cask 'sketch'
 # sketch
 
-cask 'sketch-toolbox'
+cask 'sketchpacks'
 # sketch plugin management
 
 cask 'imagealpha'


### PR DESCRIPTION
Replace `sketch-toolbox` with `sketchpacks` as default plugin manager.